### PR TITLE
Subs endpoints

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -7,6 +7,14 @@ class Api::V1::SubscriptionsController < ApplicationController
     end
   end
 
+  def update
+    subscription = Subscription.find(params[:id])
+    subscription.update(subscription_params)
+    if subscription.save
+      render json: SubscriptionSerializer.new(subscription), status: :created
+    end
+  end
+
   private
   def subscription_params
     params.require(:subscription).permit(:title, :price, :status, :frequency, :tea_name)

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::SubscriptionsController < ApplicationController
+  def create
+    user = User.find(params[:user_id])
+    subscription = user.subscriptions.create!(subscription_params)
+    if subscription.save
+      render json: SubscriptionSerializer.new(subscription), status: :created
+    end
+  end
+
+  private
+  def subscription_params
+    params.require(:subscription).permit(:title, :price, :status, :frequency, :tea_name)
+  end
+end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,2 +1,0 @@
-class SubscriptionsController < ApplicationController
-end

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,0 +1,4 @@
+class SubscriptionSerializer
+  include JSONAPI::Serializer
+  attributes :title, :price, :status, :frequency, :tea_name, :user
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :subscriptions
+      resources :subscriptions, only: [:index, :show, :update, :destroy]
+      resources :subscriptions, only: :create, path: "subscriptions/:user_id"
       resources :users
     end
   end

--- a/spec/requests/api/v1/subscriptions_request_spec.rb
+++ b/spec/requests/api/v1/subscriptions_request_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe "Subscriptions", type: :request do
+  describe "Create subscription" do
+    before do
+      @user_1 = User.create!(
+        first_name: "User 1",
+        last_name: "test",
+        email: "user1@test.com",
+        shipping_address: "123 Test st., Nowhere, NO 12321"
+      )
+      @user_2 = User.create!(
+        first_name: "User 2",
+        last_name: "test",
+        email: "user2@test.com",
+        shipping_address: "321 Fake ave., Somehere, SO 32123"
+      )
+    end
+
+    it "can create a subscription" do
+      sub_params = {
+        title: "User 2 Test Sub",
+        price: 20.0,
+        status: 1,
+        frequency: 0,
+        tea_name: "black"
+      }
+
+      headers = {"CONTENT_TYPE" => "application/json"}
+      post "/api/v1/subscriptions/#{@user_2.id}", headers: headers, params: JSON.generate(subscription: sub_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+      parsed_data = parsed_response[:data]
+
+      expect(parsed_data).to be_a(Hash)
+      expect(parsed_data[:type]).to eq("subscription")
+      expect(parsed_data[:attributes][:title]).to eq("User 2 Test Sub")
+      expect(parsed_data[:attributes][:price]).to eq(20.0)
+      expect(parsed_data[:attributes][:status]).to eq("active")
+      expect(parsed_data[:attributes][:frequency]).to eq("weekly")
+      expect(parsed_data[:attributes][:tea_name]).to eq("black")
+
+      expect(parsed_data[:attributes]).to have_key(:user)
+      expect(parsed_data[:attributes][:user][:id]).to eq(@user_2.id)
+      expect(parsed_data[:attributes][:user][:first_name]).to eq(@user_2.first_name)
+      expect(parsed_data[:attributes][:user][:last_name]).to eq(@user_2.last_name)
+      expect(parsed_data[:attributes][:user][:email]).to eq(@user_2.email)
+      expect(parsed_data[:attributes][:user][:shipping_address]).to eq(@user_2.shipping_address)
+    end
+  end
+end

--- a/spec/requests/api/v1/subscriptions_request_spec.rb
+++ b/spec/requests/api/v1/subscriptions_request_spec.rb
@@ -82,6 +82,23 @@ RSpec.describe "Subscriptions", type: :request do
       expect(parsed_data[:type]).to eq("subscription")
       expect(parsed_data[:attributes][:status]).to eq("inactive")
       expect(parsed_data[:attributes][:user][:id]).to eq(@user_1.id)
+
+      sub_params = {
+        status: 1
+      }
+
+      headers = {"CONTENT_TYPE" => "application/json"}
+      patch "/api/v1/subscriptions/#{u1_sub1.id}", headers: headers, params: JSON.generate(subscription: sub_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+      parsed_data = parsed_response[:data]
+      updated_sub = Subscription.find(u1_sub1.id)
+
+      expect(updated_sub.status).to eq("active")
+      expect(parsed_data[:attributes][:status]).to eq("active")
     end
   end
 end

--- a/spec/requests/api/v1/subscriptions_request_spec.rb
+++ b/spec/requests/api/v1/subscriptions_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Subscriptions", type: :request do
-  describe "Create subscription" do
+  describe "Create/update subscription" do
     before do
       @user_1 = User.create!(
         first_name: "User 1",
@@ -49,6 +49,39 @@ RSpec.describe "Subscriptions", type: :request do
       expect(parsed_data[:attributes][:user][:last_name]).to eq(@user_2.last_name)
       expect(parsed_data[:attributes][:user][:email]).to eq(@user_2.email)
       expect(parsed_data[:attributes][:user][:shipping_address]).to eq(@user_2.shipping_address)
+    end
+
+    it "can update activate & deactivate a subscription (toggle status)" do
+      u1_sub1 = @user_1.subscriptions.create!(
+        title: "User 1 Test Subscription 1",
+        price: 10.0,
+        status: 1,
+        frequency: 1,
+        tea_name: "green"
+      )
+
+      expect(u1_sub1.status).to eq("active")
+
+      sub_params = {
+        status: 0
+      }
+
+      headers = {"CONTENT_TYPE" => "application/json"}
+      patch "/api/v1/subscriptions/#{u1_sub1.id}", headers: headers, params: JSON.generate(subscription: sub_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+      parsed_data = parsed_response[:data]
+      updated_sub = Subscription.find(u1_sub1.id)
+
+      expect(updated_sub.id).to eq(u1_sub1.id)
+      expect(updated_sub.status).to eq("inactive")
+      expect(parsed_data[:id].to_i).to eq(u1_sub1.id)
+      expect(parsed_data[:type]).to eq("subscription")
+      expect(parsed_data[:attributes][:status]).to eq("inactive")
+      expect(parsed_data[:attributes][:user][:id]).to eq(@user_1.id)
     end
   end
 end

--- a/spec/requests/subscriptions_request_spec.rb
+++ b/spec/requests/subscriptions_request_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "Subscriptions", type: :request do
-
-end

--- a/write_ups/work_log.md
+++ b/write_ups/work_log.md
@@ -157,8 +157,8 @@ At this point, I'll stop for the day<br>
 <h5>Day 2 - Mon, July 26th 2022</h5>
 <h6>Start time for the day: 11:30 AM MST</h6>
 <h6>Start of break time: 2:00 PM MST</h6>
-<h6>End of break time: </h6>
-<h6>Break time elapsed: </h6>
+<h6>End of break time: 3:30 PM MST</h6>
+<h6>Break time elapsed: 1.5 hrs </h6>
 <h6>End time for the day: </h6>
 <h6>Time elapsed today (minus break time): </h6>
 <h6>Time elapsed thus far: </h6>
@@ -256,4 +256,9 @@ __The time is 2:00 PM MST and I need to step away for a prior engangement.__
 
 I'm adding this note and some other things above (break time start, break time end, break time elapsed) to track the time I'm actually working on the project, as opposed to time spent since the start of the project.
 
+__The time is 3:30 PM MST and I am returning to work.__
+
 <hr>
+
+Final MVP endpoint: update subscription (specifically: cancel)
+ - For the sake of time, my plan is to only give this endpoint the ability to update the subscription status between `active` and `inactive`

--- a/write_ups/work_log.md
+++ b/write_ups/work_log.md
@@ -156,8 +156,11 @@ At this point, I'll stop for the day<br>
 
 <h5>Day 2 - Mon, July 26th 2022</h5>
 <h6>Start time for the day: 11:30 AM MST</h6>
+<h6>Start of break time: 2:00 PM MST</h6>
+<h6>End of break time: </h6>
+<h6>Break time elapsed: </h6>
 <h6>End time for the day: </h6>
-<h6>Time elapsed today: </h6>
+<h6>Time elapsed today (minus break time): </h6>
 <h6>Time elapsed thus far: </h6>
 
 Today, I want to focus on endpoints. Starting with user endpoints.
@@ -239,3 +242,5 @@ From here forward, it's lots of repeating the same steps so my work log will bec
   - I found out you can add any attribute associated with the object being sent to the `attributes` section in the serializer
   - So, I added `:subscriptions`, making the attributes look like this: `attributes :first_name, :last_name, :email, :shipping_address, :subscriptions`
   - This allowed the `jsonapi-serializer` gem to auto-render a response which includes the users subscriptions!
+
+The time is 2:00 PM MST and I need to step away for a prior engangement. I'm adding this note and some other things above (break time start, break time end, break time elapsed) to track the time I'm actually working on the project, as opposed to time spent since the start of the project.

--- a/write_ups/work_log.md
+++ b/write_ups/work_log.md
@@ -243,4 +243,17 @@ From here forward, it's lots of repeating the same steps so my work log will bec
   - So, I added `:subscriptions`, making the attributes look like this: `attributes :first_name, :last_name, :email, :shipping_address, :subscriptions`
   - This allowed the `jsonapi-serializer` gem to auto-render a response which includes the users subscriptions!
 
-The time is 2:00 PM MST and I need to step away for a prior engangement. I'm adding this note and some other things above (break time start, break time end, break time elapsed) to track the time I'm actually working on the project, as opposed to time spent since the start of the project.
+<h3>Subscription endpoints:</h3>
+
+- Made the `POST` endpoint to create a subscription.
+  - The URI: `POST /api/v1/subscriptions/:user_id`
+  - I added `:user_id` so that the `create` action can find the user prior to creating the subscription.
+  - This mitigates the risk of creating a subscription with an invalid user ID
+
+<hr>
+
+__The time is 2:00 PM MST and I need to step away for a prior engangement.__
+
+I'm adding this note and some other things above (break time start, break time end, break time elapsed) to track the time I'm actually working on the project, as opposed to time spent since the start of the project.
+
+<hr>


### PR DESCRIPTION
Endpoints to:
- Create a subscription
- Update/cancel a subscription
  - Note: subs intentionally cannot be deleted. They can only be updated. This endpoint was specifically tested to ensure subscription deactivation and reactivation