### PR TITLE
Feat & test: Single subscription data

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,4 +1,9 @@
 class Api::V1::SubscriptionsController < ApplicationController
+  def show
+    subscription = Subscription.find(params[:id])
+    render json: SubscriptionSerializer.new(subscription), status: 200
+  end
+
   def create
     user = User.find(params[:user_id])
     subscription = user.subscriptions.create!(subscription_params)

--- a/spec/requests/api/v1/subscriptions_request_spec.rb
+++ b/spec/requests/api/v1/subscriptions_request_spec.rb
@@ -1,6 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe "Subscriptions", type: :request do
+  describe "get a single subscription" do
+    before do
+      @user_1 = User.create!(
+        first_name: "User 1",
+        last_name: "test",
+        email: "user1@test.com",
+        shipping_address: "123 Test st., Nowhere, NO 12321"
+      )
+      @u1_sub1 = @user_1.subscriptions.create!(
+        title: "User 1 Test Subscription 1",
+        price: 10.0,
+        status: 1,
+        frequency: 1,
+        tea_name: "green"
+      )
+      @u1_sub2 = @user_1.subscriptions.create!(
+        title: "User 1 Test Subscription 2",
+        price: 20.0,
+        status: 0,
+        frequency: 1,
+        tea_name: "black"
+      )
+    end
+
+    it "can return a single sub by the subs ID" do
+      headers = {"CONTENT_TYPE" => "application/json"}
+      get "/api/v1/subscriptions/#{@u1_sub1.id}", headers: headers
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+      parsed_data = parsed_response[:data]
+
+      expect(parsed_data).to be_a(Hash)
+      expect(parsed_data[:type]).to eq("subscription")
+      expect(parsed_data[:attributes][:title]).to eq(@u1_sub1.title)
+      expect(parsed_data[:attributes][:price]).to eq(@u1_sub1.price)
+      expect(parsed_data[:attributes][:status]).to eq(@u1_sub1.status)
+      expect(parsed_data[:attributes][:frequency]).to eq(@u1_sub1.frequency)
+      expect(parsed_data[:attributes][:tea_name]).to eq(@u1_sub1.tea_name)
+
+      expect(parsed_data[:attributes]).to have_key(:user)
+      expect(parsed_data[:attributes][:user][:id]).to eq(@user_1.id)
+    end
+  end
+  
   describe "Create/update subscription" do
     before do
       @user_1 = User.create!(

--- a/write_ups/work_log.md
+++ b/write_ups/work_log.md
@@ -262,3 +262,5 @@ __The time is 3:30 PM MST and I am returning to work.__
 
 Final MVP endpoint: update subscription (specifically: cancel)
  - For the sake of time, my plan is to only give this endpoint the ability to update the subscription status between `active` and `inactive`
+
+I have a little more time. I'm gonna create an endpoint specifically returning a single subscription.


### PR DESCRIPTION
Created an endpoint to recieve a single subscription.
This is useful because you can already get all of a users subs when you query for the user
But prior to this there was no way to view a single subscription.
This endpoint returns the subscriptions data, including the user associated w the sub and all their data